### PR TITLE
sequelizeを6系にバージョンアップ

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,13 +14,13 @@
     "helmet": "^3.8.2",
     "http-errors": "~1.6.2",
     "morgan": "~1.9.0",
-    "uuid": "^3.3.2",
     "passport": "^0.3.2",
     "passport-github2": "^0.1.9",
     "pg": "^7.17.1",
     "pg-hstore": "^2.3.3",
     "pug": "2.0.0-beta11",
-    "sequelize": "^5.21.5"
+    "sequelize": "^6.3.5",
+    "uuid": "^3.3.2"
   },
   "devDependencies": {
     "jest": "25.1.0",


### PR DESCRIPTION
findByPkが5系以上でないと使えないため、バージョンアップしました
https://sequelize.org/v5/manual/upgrade-to-v5.html